### PR TITLE
Fix base paths.

### DIFF
--- a/src/TranslationServiceProvider.php
+++ b/src/TranslationServiceProvider.php
@@ -46,12 +46,12 @@ class TranslationServiceProvider extends LaravelTranslationServiceProvider
     {
         $this->app->singleton('translation.loader', function ($app) {
             $paths = [
-                app()->basePath('vendor/caouecs/laravel-lang/src/'),
+                base_path('vendor/caouecs/laravel-lang/src/'),
             ];
 
             if ($this->inLumen) {
-                $this->app['path.lang'] = app()->basePath('vendor/laravel/lumen-framework/resources/lang');
-                array_push($paths, app()->basePath('resources/lang/'));
+                $this->app['path.lang'] = base_path('vendor/laravel/lumen-framework/resources/lang');
+                array_push($paths, base_path('resources/lang/'));
             }
 
             return new FileLoader($app['files'], $app['path.lang'], $paths);


### PR DESCRIPTION
This fix is related to issue #7.

The current laravel Application->basePath method does not accept any parameter, resulting in just the laravel base path.
Changed the app()->basePath('vendor/caouecs/laravel-lang/src/') for the helper base_path('vendor/caouecs/laravel-lang/src/').