### PR TITLE
将文件路径中的空格转义

### DIFF
--- a/src/Commands/Publish.php
+++ b/src/Commands/Publish.php
@@ -104,6 +104,11 @@ class Publish extends Command
             $files[] = base_path('vendor/laravel/lumen-framework/resources/lang/en');
         }
 
+        for ($i = 0; $i < count($files);$i++) {
+            $files[$i] = str_replace(' ','\ ', $files[$i]);
+        }
+        $targetPath = str_replace(' ','\ ', $targetPath);
+
         $files = implode(' ', $files);
         $process = new Process("cp -r{$force} $files $targetPath");
 


### PR DESCRIPTION
将文件路径中的空格转义，避免在文件路径有空格的情况下执行 php artisan lang:publish 命令出现 cp 命令报错