### PR TITLE
Remove auto discovery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,12 +22,5 @@
             "name": "overtrue",
             "email": "anzhengchao@gmail.com"
         }
-    ],
-    "extra": {
-        "laravel": {
-            "providers": [
-                "Overtrue\\LaravelLang\\TranslationServiceProvider"
-            ]
-        }
-    }
+    ]
 }


### PR DESCRIPTION
Hi,

The [documentation](https://github.com/overtrue/laravel-lang#install) says to manually replace the default `TranslationServiceProvider` with the package.

There is no need to autoload the provider from composer.json

Thanks