### PR TITLE
fix: 修复 laravel-lang/lang:10.x 版本目录结构变更导致的无法翻译

### DIFF
--- a/src/Commands/Publish.php
+++ b/src/Commands/Publish.php
@@ -37,8 +37,8 @@ class Publish extends Command
         $locale = \str_replace('-', '_', $this->argument('locales'));
         $force = $this->option('force') ? 'f' : 'n';
 
-        $sourcePath = base_path('vendor/laravel-lang/lang/src');
-        $sourceJsonPath = base_path('vendor/laravel-lang/lang/json');
+        $sourcePath = base_path('vendor/laravel-lang/lang/locales');
+        $sourceJsonPath = base_path('vendor/laravel-lang/lang/locales');
         $targetPath = base_path('resources/lang/');
 
         if (!is_dir($targetPath) && !mkdir($targetPath)) {
@@ -53,7 +53,7 @@ class Publish extends Command
         if ('all' == $locale) {
             $files = [
                 \addslashes($sourcePath).'/*',
-                escapeshellarg($sourceJsonPath),
+                \addslashes($sourceJsonPath).'/*/*.json',
             ];
             $message = 'all';
             $copyEnFiles = true;
@@ -64,8 +64,10 @@ class Publish extends Command
 
                     continue;
                 }
-                $file = $sourcePath.'/'.trim($filename);
-                $jsonFile = $sourceJsonPath.'/'.trim($filename).'.json';
+
+                $trimFilename = trim($filename);
+                $file = $sourcePath.'/'.$trimFilename;
+                $jsonFile = $sourceJsonPath."/{$trimFilename}/{$trimFilename}".'.json';
 
                 if (!file_exists($file)) {
                     $this->error("'$filename' not found.");

--- a/src/TranslationServiceProvider.php
+++ b/src/TranslationServiceProvider.php
@@ -46,7 +46,7 @@ class TranslationServiceProvider extends LaravelTranslationServiceProvider
     {
         $this->app->singleton('translation.loader', function ($app) {
             $paths = [
-                base_path('vendor/laravel-lang/lang/src/'),
+                base_path('vendor/laravel-lang/lang/locales/'),
             ];
 
             if ($this->inLumen) {
@@ -57,7 +57,7 @@ class TranslationServiceProvider extends LaravelTranslationServiceProvider
             $loader = new FileLoader($app['files'], $app['path.lang'], $paths);
 
             if (\is_callable([$loader, 'addJsonPath'])) {
-                $loader->addJsonPath(base_path('vendor/laravel-lang/lang/json/'));
+                $loader->addJsonPath(base_path('vendor/laravel-lang/lang/locales/'));
             }
 
             return $loader;


### PR DESCRIPTION
以下是 `laravel-lang/lang:10.x` 版本变更：
- `src` 目录变更为 `locales`
- 移除 `json` 目录，对应的 `json` 文件放到 `locales/xxx/xxx.json`